### PR TITLE
fix send_message to comply with new telegram api rules

### DIFF
--- a/lib/yocingo.ex
+++ b/lib/yocingo.ex
@@ -99,7 +99,7 @@ defmodule Yocingo do
   """
 
   def send_message(chat_id, text, disable_web_page_preview \\ false,
-                   reply_to_mensaje_id \\ nil, reply_markup \\ nil) do
+                   reply_to_mensaje_id \\ nil, reply_markup \\ %{"reply_markup" => []}) do
     body = {:form,[chat_id: chat_id,
                    text: text,
                    disable_web_page_preview: disable_web_page_preview,


### PR DESCRIPTION
Telegram api throws following error if reply_markup argument in send_message is nil:

%{"description" => "Bad Request: Object expected as reply markup",
  "error_code" => 400, "ok" => false}
